### PR TITLE
Remove bad use of BASE_DIR in push script

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -9,7 +9,7 @@ Source: https://github.com/uyuni-project/uyuni-releng-tools/
 # Copyright: $YEAR $NAME <$CONTACT>
 # License: ...
 
-Files: uyuni-releng-tools.changes
+Files: uyuni-releng-tools.changes*
 Copyright: 2023 SUSE LLC
 License: Apache-2.0
 

--- a/bin/push-packages-to-obs
+++ b/bin/push-packages-to-obs
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 set -e
 #
 # For all packages prepared by build-packages-for-obs.sh in
@@ -38,6 +37,10 @@ KEEP_SRPMS=${KEEP_SRPMS:-FALSE}
 
 DIFF="diff -u"
       
+GIT_DIR=$(git rev-parse --show-cdup)
+test -z "$GIT_DIR" || cd "$GIT_DIR"
+GIT_DIR=$(pwd)
+
 GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 GIT_CURR_HEAD=$(git rev-parse --short HEAD)
 
@@ -258,10 +261,10 @@ while read PKG_NAME; do
   if [ -f "$SRPM_PKG_DIR/Dockerfile" -o -f "$SRPM_PKG_DIR/Chart.yaml" ]; then
     # check which endpoint we are using to match the product
     if [ "${OSCAPI}" == "https://api.suse.de" ]; then
-        PRODUCT_VERSION="$(sed -n 's/.*web.version\s*=\s*\(.*\)$/\1/p' ${BASE_DIR}/../web/conf/rhn_web.conf)"
+        PRODUCT_VERSION="$(sed -n 's/.*web.version\s*=\s*\(.*\)$/\1/p' ${GIT_DIR}/web/conf/rhn_web.conf)"
     else
         # Uyuni settings
-        PRODUCT_VERSION="$(sed -n 's/.*web.version.uyuni\s*=\s*\(.*\)$/\1/p' ${BASE_DIR}/../web/conf/rhn_web.conf)"
+        PRODUCT_VERSION="$(sed -n 's/.*web.version.uyuni\s*=\s*\(.*\)$/\1/p' ${GIT_DIR}/web/conf/rhn_web.conf)"
     fi
     # to lowercase with ",," and replace spaces " " with "-"
     PRODUCT_VERSION=$(echo ${PRODUCT_VERSION,,} | sed -r 's/ /-/g')
@@ -272,7 +275,7 @@ while read PKG_NAME; do
       # check which endpoint we are using to match the product
       if [ "${OSCAPI}" == "https://api.suse.de" ]; then
           # SUSE Manager settings
-          VERSION=$(sed 's/^\([0-9]\+\.[0-9]\+\).*$/\1/' ${BASE_DIR}/packages/uyuni-base)
+          VERSION=$(sed 's/^\([0-9]\+\.[0-9]\+\).*$/\1/' ${GIT_DIR}/rel-eng/packages/uyuni-base)
           sed "s/^ARG INIT_IMAGE=.*$/ARG INIT_IMAGE=suse\/manager\/4.4\/init:latest/" -i $SRPM_PKG_DIR/Dockerfile
           sed "s/^ARG INIT_BASE=.*$/ARG INIT_BASE=bci\/bci-init:15.4/" -i $SRPM_PKG_DIR/Dockerfile
           sed "s/^ARG PRODUCT_PATTERN_PREFIX=.*$/ARG PRODUCT_PATTERN_PREFIX=patterns-suma/" -i $SRPM_PKG_DIR/Dockerfile
@@ -295,7 +298,7 @@ while read PKG_NAME; do
       NAME="${PKG_NAME}"
       if [ "${OSCAPI}" == "https://api.suse.de" ]; then
           # SUSE Manager settings
-          VERSION=$(sed 's/^\([0-9]\+\.[0-9]\+\).*$/\1/' ${BASE_DIR}/packages/uyuni-base)
+          VERSION=$(sed 's/^\([0-9]\+\.[0-9]\+\).*$/\1/' ${GIT_DIR}/rel-eng/packages/uyuni-base)
           sed "/^#\!BuildTag:/s/uyuni/suse\/manager\/${VERSION}/g" -i $SRPM_PKG_DIR/Chart.yaml
           sed "s/^home: .*$/home: https:\/\/www.suse.com\/products\/suse-manager\//" -i $SRPM_PKG_DIR/Chart.yaml
           CHART_TAR=$(ls ${SRPM_PKG_DIR}/*.tar)

--- a/uyuni-releng-tools.changes.cbosdonnat.path-fix
+++ b/uyuni-releng-tools.changes.cbosdonnat.path-fix
@@ -1,0 +1,1 @@
+- Fix the path when pushing containers and helm charts to OBS


### PR DESCRIPTION
BASE_DIR needs to be replaces by the git repo root path now that the script have been extracted. It worked by luck before, but not anymore when pushing containers or helm charts.