### PR TITLE
Do not hardcode a fixed release value but align it with the value used while tagging

### DIFF
--- a/bin/build-packages-for-obs
+++ b/bin/build-packages-for-obs
@@ -152,6 +152,7 @@ while read PKG_NAME PKG_VER PKG_DIR; do
   # Convert to obscpio
   SPEC_VER=$(sed -n -e 's/^Version:\s*\(.*\)/\1/p' ${T_DIR}/${PKG_NAME}.spec)
   SOURCE=$(sed -n -e 's/^\(Source\|Source0\):\s*.*[[:space:]\/]\(.*\)/\2/p' ${T_DIR}/${PKG_NAME}.spec|sed -e "s/%{name}/${PKG_NAME}/"|sed -e "s/%{version}/${SPEC_VER}/")
+  SPEC_REL=$(sed -n -e 's/^Release: \+\([0-9]\).*/\1/p' ${T_DIR}/${PKG_NAME}.spec)
   # If the package does not have sources, we don't need to repackage them
   if [ "${SOURCE}" != "" ]; then
     FOLDER=$(tar -tf ${T_DIR}/${SOURCE}|head -1|sed -e 's/\///')
@@ -176,8 +177,10 @@ commit: $(git rev-parse --verify HEAD)
 EOF
   fi
   # Release is handled by the Buildservice
-  # Remove everything what prevents us from submitting
-  sed -i 's/^Release.*$/Release:        0/i' $SRPM_DIR/$PKG_NAME/*.spec
+  # With untagged changes we can only build using --test with tito build.
+  # tito build with --test appends the git hash to the release version and we do not want this.
+  # Remove everything preventing us from submitting
+  sed -i "s/^Release.*$/Release:        ${SPEC_REL}/i" ${SRPM_DIR}/${PKG_NAME}/${PKG_NAME}.spec
 
   SUCCEED_CNT=$(($SUCCEED_CNT+1))
   break

--- a/uyuni-releng-tools.changes.deneb-alpha.do_not_hardcode_release_value
+++ b/uyuni-releng-tools.changes.deneb-alpha.do_not_hardcode_release_value
@@ -1,0 +1,2 @@
+- Do not hardcode a fixed release value but align it with the 
+  value used while tagging


### PR DESCRIPTION
Do not hardcode a fixed release value but align it with the value used while tagging.

Tested in:
* custom  OBS project https://build.suse.de/project/show/home:deneb_alpha:branches:Devel:Galaxy:Manager:Head 
* using this custom jenkins job https://ci.suse.de/view/Manager/view/Manager-Head/job/manager-Head-releng-2obs-temp-mlatini/

Now, if a source  has  been tagged using `tito tag --use-release=0` the `Release:` will  be set to `0`,  in case of sources  still tagged with the default `Release: 1` , the build script keep the `1` as  a value.

a  few examples from my branch:
* https://build.suse.de/package/show/home:deneb_alpha:branches:Devel:Galaxy:Manager:Head/billing-data-service
  * `Release:        1` in spec file
  * `- version 5.0.2-1` in .changes
  * same values in .obscpio

* https://build.suse.de/package/show/home:deneb_alpha:branches:Devel:Galaxy:Manager:Head/spacewalk-client-tools
* `Release:        0` in spec file
* `- version 5.0.4-0` in .changes
* same values in .obscpio

Same sources from `Devel:Galaxy:Manager:Head`:

* https://build.suse.de/package/show/Devel:Galaxy:Manager:Head/billing-data-service
  * `Release:    1` in spec file
  * `- version 5.0.2-1` in .changes
  * same values in .obscpio

* https://build.suse.de/package/show/Devel:Galaxy:Manager:Head/spacewalk-client-tools
  * `Release:    1` in spec file
  * `- version 5.0.4-0` in .changes
  * `Release: 0` in .obscpio

for  an untagged change,  you can look at the current version of `uyuni-releng-tools`  from this PR that is built in 
* https://build.opensuse.org/package/show/home:deneb_alpha:branches:systemsmanagement:Uyuni:Master:Docker/uyuni-releng-tools
  * `Release:        0` in spec file
  * untagged changes with the faketagger header as expected
  * `Release:        0` in .obscpio
 