### PR TITLE
Add '--commit' option to mkchlog for convenience

### DIFF
--- a/bin/mkchlog
+++ b/bin/mkchlog
@@ -24,6 +24,7 @@ The default editor can be specified by setting the EDITOR environment variable.
   -f, --feature         set the feature name to use as a filename part
   -u, --username        set the username to use as a filename part
   -r, --remove          remove existing changelog file
+  -c, --commit          do a git commit with MESSAGE as the commit message
   -n, --no-wrap         do not wrap automatically the message at 67 characters
   -h, --help            display this help and exit
 
@@ -37,7 +38,7 @@ if [ "$(uname -s)" == "Darwin" ] && $(man getopt | grep -i -q "bsd"); then
     exit 1
 fi
 
-ARGS=$(getopt -n mkchlog -o rhnf:u: --long remove,help,no-wrap,feature:username: -- "$@")
+ARGS=$(getopt -n mkchlog -o rhncf:u: --long remove,help,no-wrap,commit,feature:username: -- "$@")
 if [ $? -ne 0 ]; then
     exit 1
 fi
@@ -65,6 +66,10 @@ while [ : ]; do
             NO_WRAP=1
             shift
             ;;
+        -c|--commit)
+            COMMIT=1
+            shift
+            ;;
         --)
             shift
             break
@@ -77,12 +82,17 @@ if ! command -v git &>/dev/null; then
     exit 1
 fi
 
+if [[ -z "$1" && -n "$COMMIT" ]]; then
+    echo "'--commit' option can only be used if the MESSAGE argument is provided."
+    exit 1
+fi
+
 GITROOT=`git rev-parse --show-toplevel 2>/dev/null`
 if [ $? -ne 0 ]; then
     echo "Error: not in a git repository."
     exit 1
 fi
-    
+
 PKG_DIR=`ls -d $GITROOT/{.tito,rel-eng}/packages 2>/dev/null`
 if [ -z "$PKG_DIR" ]; then
     echo "Error: Not in Uyuni working directory."
@@ -194,6 +204,9 @@ if [ -s $CHFILE.new ]; then
     mv $CHFILE.new $CHFILE
     # Stage in git
     git add $CHFILE
+    if [[ -n "$COMMIT" && -n "$1" ]]; then
+        git commit -m "$1"
+    fi
 else
     # Unstage and remove
     echo "No entries written. Discarding the changelog file."

--- a/uyuni-releng-tools.changes
+++ b/uyuni-releng-tools.changes
@@ -1,3 +1,5 @@
+- Add '-c|--commit' option to mkchlog for convenience
+
 -------------------------------------------------------------------
 Tue Apr 09 16:07:58 CEST 2024 - marina.latini@suse.com
 


### PR DESCRIPTION
Adds '-c|--commit' option to mkchlog for convenience.

When set, `mkchlog` runs `git commit -m MESSAGE` with the `MESSAGE` used as the changelog entry.