### PR TITLE
Specify the oscrc file using --config instead of -c

### DIFF
--- a/bin/push-packages-to-obs
+++ b/bin/push-packages-to-obs
@@ -17,7 +17,7 @@ set -e
 #
 WORKSPACE=${WORKSPACE:-/tmp/push-packages-to-obs}
 PACKAGE="$@"
-OSCRC=${OSCRC:+-c $OSCRC}
+OSCRC=${OSCRC:+--config $OSCRC}
 OSCAPI=${OSCAPI:-https://api.suse.de}
 
 OSC="osc ${OSCRC} -A ${OSCAPI}"
@@ -36,7 +36,7 @@ FAKE_COMITTOBS=${FAKE_COMITTOBS:+1}
 KEEP_SRPMS=${KEEP_SRPMS:-FALSE}
 
 DIFF="diff -u"
-      
+
 GIT_DIR=$(git rev-parse --show-cdup)
 test -z "$GIT_DIR" || cd "$GIT_DIR"
 GIT_DIR=$(pwd)
@@ -327,7 +327,7 @@ while read PKG_NAME; do
           cd $OBS_TEST_PROJECT/$PKG_NAME/
           $OSC rm *
           cd -
-          cp -v * $OBS_TEST_PROJECT/$PKG_NAME  
+          cp -v * $OBS_TEST_PROJECT/$PKG_NAME
           cd $OBS_TEST_PROJECT/$PKG_NAME
           $OSC add *
           $OSC ci -m "Git submit $GIT_BRANCH($GIT_CURR_HEAD)"

--- a/uyuni-releng-tools.changes.deneb-alpha.fix_osc_config
+++ b/uyuni-releng-tools.changes.deneb-alpha.fix_osc_config
@@ -1,0 +1,1 @@
+- Specify the oscrc file using --config instead of -c


### PR DESCRIPTION
Due to a disambiguation change in osc, for specifying an alternative oscrc  path use `--config` instead of `-c`

This change has been introduced via https://smelt.suse.de/incident/32086/

Tested with modified push script in: https://build.opensuse.org/package/show/home:deneb_alpha:branches:systemsmanagement:Uyuni:Master:test_config_fix/susemanager-sls