### PR TITLE
push-packages-to-obs: add no-dereference option while diffing

### DIFF
--- a/bin/push-packages-to-obs
+++ b/bin/push-packages-to-obs
@@ -35,7 +35,9 @@ FAKE_COMITTOBS=${FAKE_COMITTOBS:+1}
 # projects in row
 KEEP_SRPMS=${KEEP_SRPMS:-FALSE}
 
-DIFF="diff -u"
+# keep the no-dereference option or
+# it could brake the diff of root.tar.gz with symlinks and empty folders
+DIFF="diff -u --no-dereference"
 
 GIT_DIR=$(git rev-parse --show-cdup)
 test -z "$GIT_DIR" || cd "$GIT_DIR"

--- a/uyuni-releng-tools.changes.deneb-alpha.fixDiffCommand
+++ b/uyuni-releng-tools.changes.deneb-alpha.fixDiffCommand
@@ -1,0 +1,1 @@
+- push-packages-to-obs: add no-dereference option while diffing


### PR DESCRIPTION
push-packages-to-obs: add no-dereference option while diffing

without the `--no-dereference` option, the diff of symlinks pointing to empty folders resulted in content being evaluated as different.

