### PR TITLE
Pin all GitHub actions to a commit

### DIFF
--- a/.github/workflows/push-2-obs.yml
+++ b/.github/workflows/push-2-obs.yml
@@ -13,7 +13,7 @@ jobs:
   push_to_obs:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           fetch-tags: true
           fetch-depth: 0

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -18,6 +18,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
     - name: REUSE Compliance Check
-      uses: fsfe/reuse-action@v2
+      uses: fsfe/reuse-action@bb774aa972c2a89ff34781233d275075cbddf542 #v5.0.0


### PR DESCRIPTION
# Description

One of the recommendations of the [Good security practices for using GitHub Actions features](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions?learn=getting_started).

For each action I went to the repository and used the last released version for the major version we were using, and specified the exact version with a comment.