### PR TITLE
Fix uyuni git submission

### DIFF
--- a/bin/push-images-to-git
+++ b/bin/push-images-to-git
@@ -39,7 +39,7 @@ GIT_CURR_HEAD=$(git rev-parse --short HEAD)
 
 ## used for exec push.sh
 PRODUCT="Uyuni"
-test "GIT_SRV" = "src.suse.de" && PRODUCT="https://api.suse.de"
+test "$GIT_SRV" = "src.suse.de" && PRODUCT="https://api.suse.de"
 GIT_DIR=$(git rev-parse --show-cdup)
 test -z "$GIT_DIR" || cd "$GIT_DIR"
 GIT_DIR=$(pwd)

--- a/bin/push-images-to-git
+++ b/bin/push-images-to-git
@@ -38,7 +38,8 @@ BRANCH=${BRANCH:-$GIT_BRANCH}
 GIT_CURR_HEAD=$(git rev-parse --short HEAD)
 
 ## used for exec push.sh
-OSCAPI=${OSCAPI:-https://api.suse.de}
+PRODUCT="Uyuni"
+test "GIT_SRV" = "src.suse.de" && PRODUCT="https://api.suse.de"
 GIT_DIR=$(git rev-parse --show-cdup)
 test -z "$GIT_DIR" || cd "$GIT_DIR"
 GIT_DIR=$(pwd)
@@ -174,7 +175,7 @@ while read PKG_NAME; do
 
   # If there is a push.sh script call it and remove it right after
   if [ -f "${SRPM_PKG_DIR}/push.sh" ]; then
-    bash "${SRPM_PKG_DIR}/push.sh" ${OSCAPI} ${GIT_DIR} ${PKG_NAME}
+    bash "${SRPM_PKG_DIR}/push.sh" ${PRODUCT} ${GIT_DIR} ${PKG_NAME}
     rm "${SRPM_PKG_DIR}/push.sh"
   fi
 

--- a/bin/push-packages-to-git
+++ b/bin/push-packages-to-git
@@ -37,7 +37,8 @@ BRANCH=${BRANCH:-$GIT_BRANCH}
 GIT_CURR_HEAD=$(git rev-parse --short HEAD)
 
 ## used for exec push.sh
-OSCAPI=${OSCAPI:-https://api.suse.de}
+PRODUCT="Uyuni"
+test "$GIT_SRV" = "src.suse.de" && PRODUCT="https://api.suse.de"
 GIT_DIR=$(git rev-parse --show-cdup)
 test -z "$GIT_DIR" || cd "$GIT_DIR"
 GIT_DIR=$(pwd)
@@ -217,7 +218,7 @@ while read PKG_NAME; do
 
   # If there is a push.sh script call it and remove it right after
   if [ -f "${SRPM_PKG_DIR}/push.sh" ]; then
-    bash "${SRPM_PKG_DIR}/push.sh" ${OSCAPI} ${GIT_DIR} ${PKG_NAME}
+    bash "${SRPM_PKG_DIR}/push.sh" ${PRODUCT} ${GIT_DIR} ${PKG_NAME}
     rm "${SRPM_PKG_DIR}/push.sh"
   fi
 

--- a/bin/push-to-obs.sh
+++ b/bin/push-to-obs.sh
@@ -155,7 +155,7 @@ CMD="$SCRIPTDIR/push-to-obs.sh ${VERBOSE} ${TEST} -d '${DESTINATIONS}' -c /tmp/.
 $EXECUTOR run --rm=true -v ${GITROOT}:/manager ${EXECUTOR_OPTS} --mount type=bind,source=${CREDENTIALS},target=/tmp/.oscrc \
 	-e C_UID \
 	-e C_GID \
-	${MOUNTCOOKIEJAR} ${MOUNTSSHKEY} ${MOUNTTEA} ${CONTAINER} /bin/bash -c "${CMD}" | tee ${GITROOT}/logs/${p}.log
+	${MOUNTCOOKIEJAR} ${MOUNTSSHKEY} ${MOUNTTEA} ${CONTAINER} /bin/bash -c "${CMD}" | tee ${GITROOT}/logs/push-to-obs.log
 
 echo "End of task at ($(date). Logs for each package at ${GITROOT}/logs/"
 


### PR DESCRIPTION
OSCAPI is not really used in the push scripts to call `osc`. It is just an identifier for the product.
If the value is `https://api.suse.de` it set the values for MLM, otherwise the values for Uyuni.

To remove the assumption that osc is called, rename the variable and use by default `Uyuni` (else tree).
To keep compatibility for the existing push scripts, set `https://api.suse.de` when we submit for MLM.

Additionally also fix an issue with the log file name.