### PR TITLE
call push.sh with a product identifier like other scripts

### DIFF
--- a/bin/push-packages-to-obs
+++ b/bin/push-packages-to-obs
@@ -39,9 +39,13 @@ KEEP_SRPMS=${KEEP_SRPMS:-FALSE}
 # it could brake the diff of root.tar.gz with symlinks and empty folders
 DIFF="diff -u --no-dereference"
 
+## used for exec push.sh
+PRODUCT="Uyuni"
+test "$OSCAPI" = "https://api.suse.de" && PRODUCT="https://api.suse.de"
 GIT_DIR=$(git rev-parse --show-cdup)
 test -z "$GIT_DIR" || cd "$GIT_DIR"
 GIT_DIR=$(pwd)
+######
 
 GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 GIT_CURR_HEAD=$(git rev-parse --short HEAD)
@@ -275,7 +279,7 @@ while read PKG_NAME; do
 
   # Is there is a push.sh script call it and remove it right after
   if [ -f "${SRPM_PKG_DIR}/push.sh" ]; then
-    bash "${SRPM_PKG_DIR}/push.sh" ${OSCAPI} ${GIT_DIR} ${PKG_NAME}
+    bash "${SRPM_PKG_DIR}/push.sh" ${PRODUCT} ${GIT_DIR} ${PKG_NAME}
     rm "${SRPM_PKG_DIR}/push.sh"
   fi
 


### PR DESCRIPTION
We adapted the other scripts already. This was missing.