### PR TITLE
Fix installation issues on non-SUSE distribution

### DIFF
--- a/uyuni-releng-tools.changes.meaksh.main-fix-installation-issues
+++ b/uyuni-releng-tools.changes.meaksh.main-fix-installation-issues
@@ -1,0 +1,1 @@
+- Fix installation issues in non-SUSE distributions

--- a/uyuni-releng-tools.spec
+++ b/uyuni-releng-tools.spec
@@ -23,8 +23,10 @@ Requires:       osc
 Requires:       tito
 Requires:       dpkg
 Requires:       curl
-Requires:       awk
+Requires:       gawk
+%if 0%{?suse_version} || 0%{?rhel} || 0%{?fedora}
 Requires:       rpmdevtools
+%endif
 
 %description
 Tools helping to prepare Uyuni release submissions.


### PR DESCRIPTION
The `rpmdevtools` package is not available in DEB based distribution, so we relax a bit the install requirements for those OSes.

The `compare-uyuni-repos.sh` script that makes use of `rpmdevtools` can be still executed to check DEB based repositories without having `rpmdevtools` installed.